### PR TITLE
update prefix name in manifest to slpp

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 declared-services:
-  sljsp-cloudantNoSQLDB:
+  slpp-cloudantNoSQLDB:
     label: cloudantNoSQLDB
     plan: Lite
 applications:
@@ -11,4 +11,4 @@ applications:
   disk_quota: 1024M
   host: shopping-list-vuejs-pouchdb-${random-word}
   services:
-  - sljsp-cloudantNoSQLDB
+  - slpp-cloudantNoSQLDB


### PR DESCRIPTION
i am proposing that we have the same prefix for the service name for all shopping list patterns, this will help to see how often this code pattern is used.

it should be noted that these two repos already have the prefix slpp:

* https://github.com/ibm-watson-data-lab/shopping-list-polymer-pouchdb/blob/master/manifest.yml#L12
* https://github.com/ibm-watson-data-lab/shopping-list-preact-pouchdb/blob/master/manifest.yml#L12
